### PR TITLE
Make it integrateable with other frameworks than Arduino

### DIFF
--- a/Timer.cpp
+++ b/Timer.cpp
@@ -111,7 +111,7 @@ void Timer::startTimer(unsigned long timeMillis)
   m_delayMillis = timeMillis;
   if (m_delayMillis > 0)
   {
-    m_currentTimeMillis = UptimeInfo::tMillis();
+    m_currentTimeMillis = UptimeInfo::Instance()->tMillis();
     startInterval();
   }
   else
@@ -124,7 +124,7 @@ void Timer::startTimer()
 {
   if (m_delayMillis > 0)
   {
-    m_currentTimeMillis = UptimeInfo::tMillis();
+    m_currentTimeMillis = UptimeInfo::Instance()->tMillis();
     startInterval();
   }
 }
@@ -147,7 +147,7 @@ void Timer::startInterval()
 
 void Timer::internalTick()
 {
-  m_currentTimeMillis = UptimeInfo::tMillis();
+  m_currentTimeMillis = UptimeInfo::Instance()->tMillis();
 
   // check if interval is over, as long as (m_delayMillis > 0)
   if ((m_delayMillis > 0) && (m_triggerTimeMillis < m_currentTimeMillis) && (m_currentTimeMillis < m_triggerTimeMillisUpperLimit))

--- a/Timer.h
+++ b/Timer.h
@@ -69,29 +69,6 @@ private:  // forbidden functions
 };
 
 /**
- * Adapter Interface, will call-out the platform specific up-time info time in milliseconds.
- */
-class UptimeInfoAdapter
-{
-public:
-  /**
-   * Up-time query call-out. To be implemented according to platform specific circumstances.
-   * @return Number of milliseconds since the program started.
-   */
-  virtual unsigned long tMillis() = 0;
-
-protected:
-  UptimeInfoAdapter() { }
-
-public:
-  virtual ~UptimeInfoAdapter() { }
-
-private:  // forbidden functions
-  UptimeInfoAdapter(const UptimeInfoAdapter& src);              // copy constructor
-  UptimeInfoAdapter& operator = (const UptimeInfoAdapter& src); // assignment operator
-};
-
-/**
  * Universal Timer.
  *
  * Features:

--- a/Timer.h
+++ b/Timer.h
@@ -69,6 +69,29 @@ private:  // forbidden functions
 };
 
 /**
+ * Adapter Interface, will call-out the platform specific up-time info time in milliseconds.
+ */
+class UptimeInfoAdapter
+{
+public:
+  /**
+   * Up-time query call-out. To be implemented according to platform specific circumstances.
+   * @return Number of milliseconds since the program started.
+   */
+  virtual unsigned long tMillis() = 0;
+
+protected:
+  UptimeInfoAdapter() { }
+
+public:
+  virtual ~UptimeInfoAdapter() { }
+
+private:  // forbidden functions
+  UptimeInfoAdapter(const UptimeInfoAdapter& src);              // copy constructor
+  UptimeInfoAdapter& operator = (const UptimeInfoAdapter& src); // assignment operator
+};
+
+/**
  * Universal Timer.
  *
  * Features:

--- a/UptimeInfo.cpp
+++ b/UptimeInfo.cpp
@@ -4,14 +4,12 @@
  *  Created on: 01.10.2013
  *      Author: niklausd
  */
-#include "Timer.h"
 #include "UptimeInfo.h"
 
 #ifdef ARDUINO
 #include "Arduino.h"
 #else
-//#include <sys/time.h>
-#include "main.h"
+#include <sys/time.h>
 #endif
 
 class DefaultUptimeInfoAdapter : public UptimeInfoAdapter
@@ -22,13 +20,12 @@ public:
 #ifdef ARDUINO
     return millis();
 #else
-///**
-// * @see http://stackoverflow.com/a/1952423
-// */
-//    struct timeval tp;
-//    gettimeofday(&tp, 0);
-//    unsigned long ms = tp.tv_sec * 1000 + tp.tv_usec / 1000;
-    unsigned long ms = HAL_GetTick();
+/**
+ * @see http://stackoverflow.com/a/1952423
+ */
+    struct timeval tp;
+    gettimeofday(&tp, 0);
+    unsigned long ms = tp.tv_sec * 1000 + tp.tv_usec / 1000;
     return ms;
 #endif
   }

--- a/UptimeInfo.h
+++ b/UptimeInfo.h
@@ -8,6 +8,8 @@
 #ifndef UPTIMEINFO_H_
 #define UPTIMEINFO_H_
 
+#include "Timer.h"
+
 /**
  * Helper class to use the appropriate time base depending on platfrom.
  * Supported platforms:
@@ -17,14 +19,46 @@
 class UptimeInfo
 {
 public:
-  UptimeInfo() { }
-  virtual ~UptimeInfo() { }
+  static inline UptimeInfo* Instance()
+  {
+    if (0 == s_instance)
+    {
+      s_instance = new UptimeInfo();
+    }
+    return s_instance;
+  }
+
+protected:
+  UptimeInfo();
+
+public:
+  virtual ~UptimeInfo();
+
+  void setAdapter(UptimeInfoAdapter* adapter);
+
+  static inline UptimeInfoAdapter* adapter()
+  {
+    return s_adapter;
+  }
 
   /**
    * Returns the number of milliseconds since the program started.
    * @return Number of milliseconds since the program started.
    */
-  static unsigned long tMillis();
+  static inline unsigned long tMillis()
+  {
+    unsigned long ms = 0;
+    if (0 != adapter())
+    {
+      ms = adapter()->tMillis();
+    }
+    return ms;
+  }
+
+
+private:
+  static UptimeInfo*        s_instance;
+  static UptimeInfoAdapter* s_adapter;
 
 private: // forbidden functions
   UptimeInfo& operator = (const UptimeInfo& src); // assignment operator

--- a/UptimeInfo.h
+++ b/UptimeInfo.h
@@ -8,7 +8,29 @@
 #ifndef UPTIMEINFO_H_
 #define UPTIMEINFO_H_
 
-#include "Timer.h"
+/**
+ * Adapter Interface, will call-out the platform specific up-time info time in milliseconds.
+ */
+class UptimeInfoAdapter
+{
+public:
+  /**
+   * Up-time query call-out. To be implemented according to platform specific circumstances.
+   * @return Number of milliseconds since the program started.
+   */
+  virtual unsigned long tMillis() = 0;
+
+protected:
+  UptimeInfoAdapter() { }
+
+public:
+  virtual ~UptimeInfoAdapter() { }
+
+private:  // forbidden functions
+  UptimeInfoAdapter(const UptimeInfoAdapter& src);              // copy constructor
+  UptimeInfoAdapter& operator = (const UptimeInfoAdapter& src); // assignment operator
+};
+
 
 /**
  * Helper class to use the appropriate time base depending on platfrom.


### PR DESCRIPTION
By default the UptimeInfo still works with wiring / Arduino framework (uses millis() function).
New: when injecting a specific UptimeInfoAdapter implementation into UptimeInfo this could be used in any environment.
Example - STM32Cube - main.cpp:

      #include "stm32l4xx_hal.h"
      #include "UptimeInfo.h"
      
      class STM32UptimeInfoAdapter : public UptimeInfoAdapter
      {
      public:
        inline unsigned long tMillis()
        {
          unsigned long ms = HAL_GetTick();
          return ms;
        }
      };

      int main(void)
      {
        // ..

        // setup 
        UptimeInfo::Instance()->setAdapter(new STM32UptimeInfoAdapter());

        while(1)
        {
          scheduleTimers();
        }
      }
